### PR TITLE
Enable realtime Supabase updates

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,13 +15,22 @@ import { Sparkles, TrendingUp, Globe, Newspaper, Brain, Calendar, BarChart3 } fr
 
 function App() {
   const [view, setView] = useState<'headlines' | 'models' | 'week' | 'month'>('headlines');
-  const { fetchModels, getFilteredModels, loading, error } = useAIStore();
+  const {
+    fetchModels,
+    getFilteredModels,
+    loading,
+    error,
+    subscribeToUpdates,
+    unsubscribeFromUpdates
+  } = useAIStore();
   const { todaysHeadlines } = useNewsStore();
   const filteredModels = getFilteredModels();
 
   useEffect(() => {
     fetchModels();
-  }, [fetchModels]);
+    subscribeToUpdates();
+    return () => unsubscribeFromUpdates();
+  }, [fetchModels, subscribeToUpdates, unsubscribeFromUpdates]);
 
   return (
     <Layout>

--- a/src/components/TodaysHeadlines.tsx
+++ b/src/components/TodaysHeadlines.tsx
@@ -7,11 +7,20 @@ import { Glass } from './ui/Glass';
 import { GlowText } from './ui/GlowText';
 
 export function TodaysHeadlines() {
-  const { todaysHeadlines, loading, error, fetchTodaysHeadlines } = useNewsStore();
+  const {
+    todaysHeadlines,
+    loading,
+    error,
+    fetchTodaysHeadlines,
+    subscribeToNews,
+    unsubscribeFromNews
+  } = useNewsStore();
 
   useEffect(() => {
     fetchTodaysHeadlines();
-  }, [fetchTodaysHeadlines]);
+    subscribeToNews();
+    return () => unsubscribeFromNews();
+  }, [fetchTodaysHeadlines, subscribeToNews, unsubscribeFromNews]);
 
   const criticalNews = todaysHeadlines.filter(news => news.importance_score && news.importance_score >= 8);
   const importantNews = todaysHeadlines.filter(news => news.importance_score && news.importance_score >= 6 && news.importance_score < 8);


### PR DESCRIPTION
## Summary
- subscribe to `postgres_changes` for `ai_news` and `ai_updates`
- append new rows in Zustand stores
- clean up realtime subscriptions when components unmount

## Testing
- `npm run lint` *(fails: Cannot find package)*

------
https://chatgpt.com/codex/tasks/task_e_68761bf087f88320a4e1f3f62aa4e981